### PR TITLE
deleted second grid-template-columns property

### DIFF
--- a/style.css
+++ b/style.css
@@ -142,8 +142,4 @@ hr {
 	.projects-grid {
 		grid-template-columns: 100%;
 	}
-
-	.links-and-contact {
-		grid-template-columns: 100%;
-	}
 }


### PR DESCRIPTION
When I was running this code, the email section wasnt rendering in line with links as we want it to be, until I found out we basically gave the same command twice and browser just ignored grid-template-columns: 30% 70% property and were rendering grid-template-columns: 100% instead. So I deleted the second option with 100% and all works perfectly now. Hope it helps.